### PR TITLE
fix(Cache): Revert "[#264] disable cache by default but allow caching"

### DIFF
--- a/src/services/request.ts
+++ b/src/services/request.ts
@@ -6,7 +6,6 @@ export interface IRequestParameters {
   body?: any;
   forceHttp?: boolean;
   'bearer-token'?: string;
-  'allow-cache'?: boolean; // default false
 }
 
 export default async function request (obj: IRequestParameters): Promise<any> {
@@ -25,6 +24,10 @@ export default async function request (obj: IRequestParameters): Promise<any> {
     // server
     const XHR = typeof XMLHttpRequest === 'undefined' ? xhrPolyfill : XMLHttpRequest;
     const request: XMLHttpRequest = new XHR();
+
+    if (obj['bearer-token']) {
+      request.setRequestHeader('Authorization', `Bearer ${obj['bearer-token']}`);
+    }
 
     request.onload = () => {
       if (request.status >= 200 && request.status < 300) {
@@ -52,14 +55,6 @@ export default async function request (obj: IRequestParameters): Promise<any> {
     };
 
     request.open(obj.method || 'GET', url);
-
-    if (obj['bearer-token']) {
-      request.setRequestHeader('Authorization', `Bearer ${obj['bearer-token']}`);
-    }
-
-    if (!obj['allow-cache']) {
-      request.setRequestHeader('Cache-Control', 'no-cache, no-store, max-age=0');
-    }
 
     if (obj.body) {
       request.send(JSON.stringify(obj.body));

--- a/tests/services/request.test.ts
+++ b/tests/services/request.test.ts
@@ -34,9 +34,7 @@ function MockXMLHttpRequestFactory ({ isSuccessCase }: { isSuccessCase: boolean 
     onload (): any {}
 
     // eslint-disable-next-line @typescript-eslint/no-empty-function
-    setRequestHeader (name: string, value: string): any {
-      this.headers[name] = value;
-    }
+    setRequestHeader (name: string, value: string): any {}
   };
 }
 
@@ -98,52 +96,6 @@ describe('Services Request test suite', function () {
         'bearer-token': 'my-bearer-token'
       });
       expect(setRequestHeaderStub.getCall(0).args).toEqual(['Authorization', 'Bearer my-bearer-token']);
-    });
-  });
-
-  describe('given the allow-cache option is undefined', function () {
-    it('should set the Cache-Control header to disallow caching', async function () {
-      // @ts-expect-error open takes params but does not pick them up from the class definition and TS complains...
-      const setRequestHeaderStub = sinon.stub<[string, string]>(MockXMLHttpRequestSuccess.prototype, 'setRequestHeader');
-      await request({
-        url: 'https://www.test.com'
-      });
-      expect(setRequestHeaderStub.getCall(0).args).toEqual(['Cache-Control', 'no-cache, no-store, max-age=0']);
-    });
-  });
-
-  describe('given the allow-cache option is false', function () {
-    it('should set the Cache-Control header to disallow caching', async function () {
-      // @ts-expect-error open takes params but does not pick them up from the class definition and TS complains...
-      const setRequestHeaderStub = sinon.stub<[string, string]>(MockXMLHttpRequestSuccess.prototype, 'setRequestHeader');
-      await request({
-        url: 'https://www.test.com',
-        'allow-cache': false
-      });
-      expect(setRequestHeaderStub.getCall(0).args).toEqual(['Cache-Control', 'no-cache, no-store, max-age=0']);
-    });
-  });
-
-  describe('given the allow-cache option is true', function () {
-    it('should not set the Cache-Control header', async function () {
-      // @ts-expect-error open takes params but does not pick them up from the class definition and TS complains...
-      const setRequestHeaderStub = sinon.stub<[string, string]>(MockXMLHttpRequestSuccess.prototype, 'setRequestHeader');
-      await request({
-        url: 'https://www.test.com',
-        'allow-cache': true
-      });
-      expect(setRequestHeaderStub.calledOnce).toBe(false);
-    });
-  });
-
-  describe('given the allow-cache option is false', function () {
-    it('should set the Cache-Control header to disallow caching', async function () {
-      // @ts-expect-error open takes params but does not pick them up from the class definition and TS complains...
-      const setRequestHeaderStub = sinon.stub<[string, string]>(MockXMLHttpRequestSuccess.prototype, 'setRequestHeader');
-      await request({
-        url: 'https://www.test.com'
-      });
-      expect(setRequestHeaderStub.getCall(0).args).toEqual(['Cache-Control', 'no-cache, no-store, max-age=0']);
     });
   });
 


### PR DESCRIPTION
some issues have appeared as servers can reject some requests if disallowed headers are set.
As this is unpredictable, it seems frontend forcing cache control is not the right approach to solve #264 