### PR TITLE
fix(etherscan): upgrade to V2 API

### DIFF
--- a/src/explorers/ethereum/etherscan.ts
+++ b/src/explorers/ethereum/etherscan.ts
@@ -8,7 +8,7 @@ import { SupportedChains } from '../../constants/supported-chains.js';
 import { type TransactionData } from '../../models/transactionData';
 import { type ExplorerAPI, type IParsingFunctionAPI } from '../../models/explorers';
 
-const MAIN_API_BASE_URL = 'https://api.etherscan.io/api?module=proxy';
+const MAIN_API_BASE_URL = 'https://api.etherscan.io/v2/api?chainid=1&module=proxy';
 
 function getApiBaseURL (chain: SupportedChains): string {
   const testnetNameMap = {

--- a/tests/services/transaction-apis.test.ts
+++ b/tests/services/transaction-apis.test.ts
@@ -44,7 +44,7 @@ describe('Transaction APIs test suite', function () {
           expect(buildTransactionServiceUrl({
             explorerAPI: fixtureApi,
             transactionId: fixtureTransactionId
-          })).toEqual(`https://api.etherscan.io/api?module=proxy&action=eth_getTransactionByHash&txhash=${fixtureTransactionId}`);
+          })).toEqual(`https://api.etherscan.io/v2/api?chainid=1&module=proxy&action=eth_getTransactionByHash&txhash=${fixtureTransactionId}`);
         });
       });
 
@@ -54,7 +54,7 @@ describe('Transaction APIs test suite', function () {
             explorerAPI: fixtureApi,
             transactionId: fixtureTransactionId,
             chain: SupportedChains.Ethmain
-          })).toEqual(`https://api.etherscan.io/api?module=proxy&action=eth_getTransactionByHash&txhash=${fixtureTransactionId}`);
+          })).toEqual(`https://api.etherscan.io/v2/api?chainid=1&module=proxy&action=eth_getTransactionByHash&txhash=${fixtureTransactionId}`);
         });
       });
 
@@ -125,19 +125,19 @@ describe('Transaction APIs test suite', function () {
             explorerAPI: fixtureApi,
             transactionId: fixtureTransactionId
           });
-          const expectedOutput = `https://api.etherscan.io/api?module=proxy&action=eth_getTransactionByHash&txhash=${fixtureTransactionId}&apikey=${fixtureAPIToken}`;
+          const expectedOutput = `https://api.etherscan.io/v2/api?chainid=1&module=proxy&action=eth_getTransactionByHash&txhash=${fixtureTransactionId}&apikey=${fixtureAPIToken}`;
           expect(output).toBe(expectedOutput);
         });
       });
 
       describe('and there are no parameters in the URL yet', function () {
         it('should construct the URL to add the token with ?', function () {
-          fixtureApi.serviceURL = 'https://api.etherscan.io/api';
+          fixtureApi.serviceURL = 'https://api.etherscan.io/v2/api';
           const output = buildTransactionServiceUrl({
             explorerAPI: fixtureApi,
             transactionId: fixtureTransactionId
           });
-          const expectedOutput = `https://api.etherscan.io/api?apikey=${fixtureAPIToken}`;
+          const expectedOutput = `https://api.etherscan.io/v2/api?apikey=${fixtureAPIToken}`;
           expect(output).toBe(expectedOutput);
         });
       });


### PR DESCRIPTION
Hi there, as you may be aware, Etherscan is shutting down V1 of their API:  https://info.etherscan.com/switch-to-etherscan-api-v2-by-may-31-2025/ (they extended the deadline until August 15).

In this PR I've updated the Etherscan API URLs to use V2 endpoints. If you'd like additional info, here's the V2 migration guide: https://docs.etherscan.io/etherscan-v2/v2-quickstart

All the tests passed when I ran them, and I'm using the new endpoint in Digit.ink's SaaS already, though if you'd like to conduct your own testing, that would be quite welcome. 

Feel free to let me know if there's anything else I can help with here.